### PR TITLE
feat: Badge Component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,10 @@
-import Badge from "@/liftkit/components/badge";
 import styles from "./page.module.css";
 import Welcome from "@/content/components/button.mdx";
 
 export default function Home() {
   return (
     <div className={styles.page}>
-      <Badge icon="replace" color="surfacecontainerhigh" scale="lg" iconStrokeWidth={1}/>
-      <span className="absolute top-0">Hello</span>
-      {/* <Welcome /> */}
+      <Welcome />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,13 @@
+import Badge from "@/liftkit/components/badge";
 import styles from "./page.module.css";
 import Welcome from "@/content/components/button.mdx";
 
 export default function Home() {
   return (
     <div className={styles.page}>
-      <Welcome />
+      <Badge icon="replace" color="surfacecontainerhigh" scale="lg" iconStrokeWidth={1}/>
+      <span className="absolute top-0">Hello</span>
+      {/* <Welcome /> */}
     </div>
   );
 }

--- a/src/liftkit/components/badge/index.tsx
+++ b/src/liftkit/components/badge/index.tsx
@@ -6,19 +6,17 @@ interface LkBadgeProps extends React.HTMLAttributes<HTMLDivElement> {
   icon?: IconName;
   color?: LkColorWithOnToken;
   scale?: "md" | "lg";
-  // iconStrokeWidth?: number;
+  iconStrokeWidth?: number;
 }
 
 export default function Badge({
   icon = "roller-coaster",
   color = "surface",
   scale = "md",
-  // iconStrokeWidth = 1,
+  iconStrokeWidth = 1,
   ...restProps
 }: LkBadgeProps) {
   const iconColor = getOnToken(color) as LkColor;
-
-  console.log(iconColor);
 
   return (
     <div
@@ -28,7 +26,7 @@ export default function Badge({
       {...restProps}
     >
       <div lk-component="slot" lk-slot="icon">
-        <Icon name={icon} color={iconColor} strokeWidth={1}></Icon>
+        <Icon name={icon} color={iconColor} strokeWidth={iconStrokeWidth}></Icon>
       </div>
     </div>
   );


### PR DESCRIPTION
**Description:**
This PR introduces a reusable `<Badge>` component designed to display an icon with color and size customization. It uses Liftkit conventions for styling via `lk-*` attributes and leverages a utility function to compute the appropriate on-token color for contrast.

**Changes** Included:

Introduced Badge component with the following props:

icon (default: "roller-coaster")

color: uses `getOnToken()` to determine the appropriate contrasting icon color (default: "surface")

scale: "md" or "lg" (default: "md")

iconStrokeWidth: customizable line weight for the icon

Utilizes `k-component`, `lk-badge-scale`, and other Liftkit-compatible attributes for structure and styling

Uses the Icon component and integrates with `lucide-react/dynamic`

Next **Steps:**

Review design consistency

**Note:** The component does not yet match the exact dimensions specified in the Figma design

closes #28 (Badge Component)