### PR TITLE
feat: Container Component

### DIFF
--- a/src/liftkit/components/containers/index.tsx
+++ b/src/liftkit/components/containers/index.tsx
@@ -8,15 +8,15 @@ interface LkContainerProps extends React.HTMLAttributes<HTMLDivElement> {
 export default function Container({
   maxWidth = "md",
   children,
-  ...rest
+  ...restProps
 }: LkContainerProps) {
   const dataAttrs = useMemo(
-    () => propsToDataAttrs({ maxWidth }, "lk-container"),
+    () => propsToDataAttrs({ maxWidth }, "container"),
     [maxWidth],
   );
 
   return (
-    <div {...dataAttrs} {...rest}>
+    <div {...dataAttrs} {...restProps}>
       {children}
     </div>
   );

--- a/src/liftkit/css/containers.css
+++ b/src/liftkit/css/containers.css
@@ -68,3 +68,41 @@
   margin-right: auto;
   max-width: none;
 }
+
+
+
+[lk-container-max-width="xs"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 767px;
+}
+
+[lk-container-max-width="sm"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 992px;
+}
+
+[lk-container-max-width="md"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1257px;
+}
+
+[lk-container-max-width="lg"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1600px;
+}
+
+[lk-container-max-width="xl"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1806.4px;
+}
+
+[lk-container-max-width="none"] {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: none;
+}


### PR DESCRIPTION
**Description:**
This issue implements a reusable `<Container>` component that supports setting a `maxWidth` via Liftkit-style data attributes.

**Changes** **Included:**

Added Container component that accepts:

maxWidth: optional prop with default "md" (type: LkContainerWidth)

All native `div` props via `React.HTMLAttributes<HTMLDivElement>`

Applies global styling via `lk-container-max-width` data attribute -- changed from `lk-container-max-w`

Uses `propsToDataAttrs` to handle attribute transformation



closes #31  (Container Component)