### PR TITLE
feat: Heading Component

### DIFF
--- a/src/liftkit/components/heading/index.tsx
+++ b/src/liftkit/components/heading/index.tsx
@@ -6,24 +6,28 @@ type LkHeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 interface LkHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
   tag?: LkHeadingTag;
   fontClass?: string; // Should be LkFontClass in production
-  content?: string;
+  children?: React.ReactNode;
+  fontColor?: string
+  // content?: string;
 }
 
 export default function Heading({
   tag = "h2",
   fontClass = "display2-bold",
-  content = "Heading",
-  ...rest
+fontColor,
+  // content = "Heading",
+  children,
+  ...restProps
 }: LkHeadingProps) {
   const headingAttrs = useMemo(
-    () => propsToDataAttrs(rest, "lk-heading"),
-    [rest],
+    () => propsToDataAttrs(restProps, "heading"),
+    [restProps],
   );
   const Tag = tag;
 
   return (
-    <Tag className={`lk-font-${fontClass}`} {...headingAttrs}>
-      {content}
+    <Tag lk-component="heading" className={`${fontClass} color-${fontColor}`} {...headingAttrs}>
+      {children}
     </Tag>
   );
 }


### PR DESCRIPTION
### **Summary**
Created the `Heading` component to support a new `fontColor` prop, allowing users to apply a consistent color-* class directly to the heading element, instead of requiring styling at the parent level.

### **What's Changed**
Props added:

tag (h1–h6) — sets the semantic tag (default: h2)

fontClass — sets font utility class (default: display2-bold)

fontColor — appends a `color-{fontColor}` class (e.g. color-light__primary)

children — text or content rendered inside the heading

Removed legacy `content` prop in favor of children for standard React behavior.

### **Example usage:**

```
<Heading tag="h1" fontClass="title1" fontColor="light__primary">
  Welcome
</Heading>
```

### **Reasoning**
Even though users could previously apply text color by styling the parent container, adding fontColor directly improves flexibility and supports standalone component usage — especially with utility classes like .color-light__primary or any predefined lkColor types.

closes #36 (Heading component)