### PR TITLE
feature: Paragraph Component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,23 @@
 import Badge from "@/liftkit/components/badge";
 import styles from "./page.module.css";
+import Paragraph from "@/liftkit/components/paragraph";
 
 export default function Home() {
   return (
     <div className={styles.page}>
       <Badge></Badge>
+      <Paragraph fontClass="title1">
+        ancient times, cats were not merely companions—they were revered as
+        divine beings. Cultures like ancient Egypt honored cats as sacred
+        creatures, embodying grace, mystery, and spiritual power. The goddess
+        Bastet, depicted with the head of a lioness or domestic cat, symbolized
+        protection, fertility, and the nurturing aspects of home life. Even
+        beyond Egypt, the enigmatic nature of cats—their watchful eyes, silent
+        movements, and uncanny independence—has inspired a timeless belief that
+        they walk between worlds. To this day, many still joke (or suspect) that
+        cats aren’t just pets, but deities in disguise, quietly ruling their
+        human households with regal indifference.
+      </Paragraph>
     </div>
   );
 }

--- a/src/liftkit/components/paragraph/index.tsx
+++ b/src/liftkit/components/paragraph/index.tsx
@@ -2,23 +2,23 @@ import { useMemo } from "react";
 import { propsToDataAttrs } from "../utilities";
 
 interface LkParagraphProps extends React.HTMLAttributes<HTMLParagraphElement> {
-  fontClass?: string; // Should be LkFontClass in production
+  fontClass?: LkFontClass; // Should be LkFontClass in production
   content?: string;
 }
 
 export default function Paragraph({
   fontClass = "body",
-  content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.",
+  children,
   ...rest
 }: LkParagraphProps) {
   const paragraphAttrs = useMemo(
-    () => propsToDataAttrs(rest, "lk-paragraph"),
+    () => propsToDataAttrs(rest, "paragraph"),
     [rest],
   );
 
   return (
-    <p className={`lk-font-${fontClass}`} {...paragraphAttrs}>
-      {content}
+    <p lk-component="paragraph" className={`${fontClass}`} {...paragraphAttrs}>
+      {children}
     </p>
   );
 }

--- a/src/liftkit/components/vanilla/paragraph.css
+++ b/src/liftkit/components/vanilla/paragraph.css
@@ -4,3 +4,152 @@
   display: block;
   margin: 0;
 }
+
+/* Display */
+[lk-paragraph-font-class="display1"] {
+  font-size: var(--display1-font-size);
+  font-weight: 400;
+  line-height: var(--lk-quarterstep);
+  letter-spacing: -0.022em;
+}
+
+[lk-paragraph-font-class="display2"] {
+  font-size: var(--display2-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.022em;
+}
+
+/* Title */
+[lk-paragraph-font-class="title1"] {
+  font-size: var(--title1-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.022em;
+}
+
+[lk-paragraph-font-class="title2"] {
+  font-size: var(--title2-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.02em;
+}
+
+[lk-paragraph-font-class="title3"] {
+  font-size: var(--title3-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.017em;
+}
+
+/* Heading & Subheading */
+[lk-paragraph-font-class="heading"] {
+  font-size: var(--heading-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.014em;
+}
+
+[lk-paragraph-font-class="subheading"] {
+  font-size: var(--subheading-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.007em;
+}
+
+/* Body */
+[lk-paragraph-font-class="body"] {
+  font-size: 1em;
+  font-weight: 400;
+  line-height: var(--lk-wholestep);
+  letter-spacing: -0.011em;
+  cursor: default;
+}
+
+/* Callout */
+[lk-paragraph-font-class="callout"] {
+  font-size: var(--callout-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.009em;
+}
+
+/* Label */
+[lk-paragraph-font-class="label"] {
+  font-size: var(--label-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.004em;
+}
+
+/* Caption */
+[lk-paragraph-font-class="caption"] {
+  font-size: var(--caption-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.007em;
+}
+
+/* Capline */
+[lk-paragraph-font-class="capline"] {
+  font-size: var(--capline-font-size);
+  font-weight: 400;
+  line-height: var(--lk-halfstep);
+  letter-spacing: 0.0618em;
+  text-transform: uppercase;
+}
+
+/* --- Bold Variants --- */
+
+/* Display Bold */
+[lk-paragraph-font-class="display1-bold"] {
+  font-size: var(--display1-font-size);
+  font-weight: 700;
+  line-height: var(--lk-quarterstep);
+  letter-spacing: -0.022em;
+}
+
+[lk-paragraph-font-class="display2-bold"] {
+  font-size: var(--display2-font-size);
+  font-weight: 700;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.022em;
+}
+
+/* Title Bold */
+[lk-paragraph-font-class="title1-bold"] {
+  font-size: var(--title1-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.022em;
+}
+
+[lk-paragraph-font-class="title2-bold"] {
+  font-size: var(--title2-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.02em;
+}
+
+[lk-paragraph-font-class="title3-bold"] {
+  font-size: var(--title3-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.017em;
+}
+
+/* Heading Bold */
+[lk-paragraph-font-class="heading-bold"] {
+  font-size: var(--heading-font-size);
+  font-weight: 700;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.014em;
+}
+
+/* Subheading Bold */
+[lk-paragraph-font-class="subheading-bold"] {
+  font-size: var(--subheading-font-size);
+  font-weight: 600;
+  line-height: var(--lk-halfstep);
+  letter-spacing: -0.007em;
+}


### PR DESCRIPTION
### **Description:**

Paragraph component with customizable font styles using the `fontClass` prop. Key features:

Accepts `fontClass` (default: "body") and content props.

Applies font styles via `lk-paragraph-font-class` data attributes.

Uses `propsToDataAttrs` utility to pass arbitrary HTML attributes prefixed for tracking/styling.

Includes a complete set of font-class-based styles for display, title, heading, body, callout, label, caption, and capline text, including bold variants.

In production, `fontClass` should be typed as `LkFontClass` for stronger type safety.

closes #44 (paragraph component)