### PR TITLE
feat: Row Component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,31 @@
-import Icon from "@/liftkit/components/icon";
-import Badge from "@/liftkit/components/badge";
-import styles from "./page.module.css";
+
+import Row from "@/liftkit/components/row";
 
 export default function Home() {
   return (
-    <div className={styles.page}>
-      <Icon name="airplay" color="primary" fontClass="title2"/>
-      <Badge></Badge>
+    <div>
+    <div style={{ padding: "2rem" }}>
+      <h2>Row with gap, justifyContent, alignItems</h2>
+      <Row gap="lg" justify-content="space-around" align-items="center">
+        <div style={{ background: "#ddd", padding: "1rem" }}>Item 1</div>
+        <div style={{ background: "#bbb", padding: "1rem" }}>Item 2</div>
+        <div style={{ background: "#999", padding: "1rem" }}>Item 3</div>
+      </Row>
+
+      <h2 style={{ marginTop: "2rem" }}>Row with wrapChildren</h2>
+      <Row gap="lg" wrap-children="true" style={{ maxWidth: "300px" }}>
+        <div style={{ background: "#ccc", width: "200px", padding: "1rem" }}>A</div>
+        <div style={{ background: "#aaa", width: "200px", padding: "1rem" }}>B</div>
+        <div style={{ background: "#888", width: "200px", padding: "1rem" }}>C</div>
+      </Row>
+
+      <h2 style={{ marginTop: "2rem" }}>Row with defaultChildBehavior = auto-grow</h2>
+      <Row gap="sm" default-child-behavior="auto-grow">
+        <div style={{ background: "#eef", padding: "1rem" }}>Grow 1</div>
+        <div style={{ background: "#ccf", padding: "1rem" }}>Grow 2</div>
+        <div style={{ background: "#aaf", padding: "1rem" }}>Grow 3</div>
+      </Row>
+    </div>
     </div>
   );
 }

--- a/src/liftkit/components/row/index.tsx
+++ b/src/liftkit/components/row/index.tsx
@@ -34,9 +34,9 @@ export default function Row(props: LkRowProps) {
   const { children, ...restProps } = props;
 
   const lkRowAttrs = useMemo(
-    () => propsToDataAttrs(restProps, "lk-row"),
+    () => propsToDataAttrs(restProps, "row"),
     [restProps],
   );
 
-  return <div {...lkRowAttrs}>{children}</div>;
+  return <div {...lkRowAttrs} {...restProps} lk-component="row">{children}</div>;
 }

--- a/src/liftkit/components/vanilla/row.css
+++ b/src/liftkit/components/vanilla/row.css
@@ -1,6 +1,6 @@
 @import "../../liftkit-core.css";
 
-css CopyEdit [lk-component="row"] {
+[lk-component="row"] {
   display: flex;
   flex-direction: row;
   flex-wrap: nowrap;


### PR DESCRIPTION
### **Description:**

 `Row` component designed to simplify horizontal layout logic using lk-* data attributes. 

Accepts props to control:

alignItems
justifyContent
gap (based on LkSizeUnit)
wrapChildren (wrap vs no-wrap)
defaultChildBehavior (flex grow/shrink rules)

The related CSS styles are defined in liftkit-core.css and use attribute selectors to drive layout behavior.

closes #45 (row component)