### PR TITLE
fix: import path for globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,1 @@
-@import "@/registry/universal/lib/css/index.css";
+@import "../../registry/universal/lib/css/index.css"


### PR DESCRIPTION
fix import path to use an absolute directory instead of an import alias because it wasn't functioning properly. related to #112 