### PR TITLE
fix: grid column count handling and gap props

### DIFF
--- a/registry/nextjs/components/grid/index.tsx
+++ b/registry/nextjs/components/grid/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useMemo } from "react";
 import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/grid/grid.css";
@@ -9,19 +10,39 @@ interface LkGridProps extends React.HTMLAttributes<HTMLDivElement> {
   autoResponsive?: boolean; // Mark as optional since we provide a default
 }
 
+/**
+ * A responsive grid component that provides flexible layout options.
+ *
+ * @param columns - The number of columns for the grid layout
+ * @param gap - The spacing between grid items
+ * @param autoResponsive - Whether the grid should automatically adjust to different screen sizes. Defaults to false
+ * @param children - The child elements to be rendered within the grid
+ * @param restProps - Additional props that will be passed to the underlying div element
+ *
+ * @returns A div element with grid layout styling and data attributes
+ */
 export default function Grid({
+  columns,
+  gap = "md",
   autoResponsive = false, // Default value
   children,
   ...restProps
 }: LkGridProps) {
   const lkGridAttrs = useMemo(
-    () => propsToDataAttrs({ ...restProps, autoResponsive }, "grid"),
-    [restProps, autoResponsive],
+    () => propsToDataAttrs({ autoResponsive, gap, ...restProps }, "grid"),
+    [autoResponsive, columns, gap]
   );
 
   return (
-    <div lk-component="grid" {...lkGridAttrs}>
-      {children}
-    </div>
+    <>
+      <div
+        lk-component="grid"
+        {...lkGridAttrs}
+        {...restProps}
+        style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+      >
+        {children}
+      </div>
+    </>
   );
 }

--- a/registry/nextjs/components/grid/index.tsx
+++ b/registry/nextjs/components/grid/index.tsx
@@ -5,8 +5,8 @@ import "@/registry/nextjs/components/grid/grid.css";
 
 // The LiftkitGrid type definition
 interface LkGridProps extends React.HTMLAttributes<HTMLDivElement> {
-  columns: number;
-  gap: LkSizeUnit;
+  columns?: number;
+  gap?: LkSizeUnit;
   autoResponsive?: boolean; // Mark as optional since we provide a default
 }
 
@@ -22,7 +22,7 @@ interface LkGridProps extends React.HTMLAttributes<HTMLDivElement> {
  * @returns A div element with grid layout styling and data attributes
  */
 export default function Grid({
-  columns,
+  columns = 2,
   gap = "md",
   autoResponsive = false, // Default value
   children,

--- a/src/app/staging/button/page.tsx
+++ b/src/app/staging/button/page.tsx
@@ -42,14 +42,15 @@ export default function Staging() {
           Hello world!
         </Heading>
       </Section>
-      <Row alignItems="start" style={{ gap: "var(--lk-size-md)" }} className="w-full" wrapChildren={true}>
+      <Grid columns={4} gap="md" style={{alignItems: "center", justifyItems: "center"}}>
+
         {(() => {
           const sizes = ["sm", "md", "lg"];
           const iconConfigs = [
             { startIcon: undefined, endIcon: undefined, label: "No Icons" },
-            { startIcon: "circle", endIcon: undefined, label: "Start Icon" },
-            { startIcon: undefined, endIcon: "circle", label: "End Icon" },
-            { startIcon: "circle", endIcon: "circle", label: "Both Icons" },
+            { startIcon: "airplay", endIcon: undefined, label: "Start Icon" },
+            { startIcon: undefined, endIcon: "airplay", label: "End Icon" },
+            { startIcon: "airplay", endIcon: "airplay", label: "Both Icons" },
           ];
 
           const generateButtons = (
@@ -81,6 +82,7 @@ export default function Staging() {
                 startIcon={currentConfig.startIcon as IconName | undefined}
                 endIcon={currentConfig.endIcon as IconName | undefined}
                 opticIconShift={false}
+                style={{alignSelf: "center", justifySelf: "center"}}
               />
             );
 
@@ -101,110 +103,8 @@ export default function Staging() {
 
           return generateButtons(buttonColors, buttonVariants, sizes, iconConfigs);
         })()}
-      </Row>
-      <Row alignItems="start" style={{ gap: "var(--lk-size-md)" }} className="w-full" wrapChildren={true}>
-        {/* Small Buttons */}
-
-        <Column style={{ gap: "var(--lk-size-md)" }} justifyContent="start">
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="fill"
-              color={color}
-              size="sm"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="outline"
-              color={color}
-              size="sm"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="text"
-              color={color}
-              size="sm"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-
-        {/* Normal Buttons */}
-
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button key={index} label="Button" variant="fill" color={color} size="md" startIcon="circle"></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button key={index} label="Button" variant="outline" color={color} size="md" startIcon="circle"></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button key={index} label="Button" variant="text" color={color} size="md" startIcon="circle"></Button>
-          ))}
-        </Column>
-
-        {/* Large buttons */}
-
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="fill"
-              color={color}
-              size="lg"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="outline"
-              color={color}
-              size="lg"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-        <Column style={{ gap: "var(--lk-size-md)" }}>
-          {buttonColors.map((color, index) => (
-            <Button
-              key={index}
-              label="Button"
-              variant="text"
-              color={color}
-              size="lg"
-              startIcon="circle"
-              opticIconShift={false}
-            ></Button>
-          ))}
-        </Column>
-      </Row>
+      </Grid>
+      <Row alignItems="start" style={{ gap: "var(--lk-size-md)" }} className="w-full" wrapChildren={true}></Row>
     </div>
   );
 }


### PR DESCRIPTION
Related to #124 
- Makes column count totally dynamic by passing it as an inline style. No more limit of 12 columns
- Assigns a default column count of 2
- Assigns a default gap prop of "md"