### PR TITLE
fix: explicitly destructure all props across components

### DIFF
--- a/registry/nextjs/components/column/index.tsx
+++ b/registry/nextjs/components/column/index.tsx
@@ -4,22 +4,19 @@ import "@/registry/nextjs/components/column/column.css";
 
 interface LkColumnProps extends React.HTMLAttributes<HTMLDivElement> {
   alignItems?: "start" | "center" | "end" | "stretch";
-  justifyContent?:
-    | "start"
-    | "center"
-    | "end"
-    | "space-between"
-    | "space-around";
-  children?: React.ReactNode;
+  justifyContent?: "start" | "center" | "end" | "space-between" | "space-around";
   gap?: LkSizeUnit;
+  wrapChildren?: boolean;
+  defaultChildBehavior?: "auto-grow" | "auto-shrink" | "ignoreFlexRules" | "ignoreIntrinsicSize";
+  children?: React.ReactNode;
 }
 
 export default function Column(props: LkColumnProps) {
-  const { children, alignItems, justifyContent, gap, ...restProps } = props;
+  const { children, alignItems="start", justifyContent="start", gap, wrapChildren, defaultChildBehavior, ...restProps } = props;
 
   const lkColumnAttrs = useMemo(
-    () => propsToDataAttrs({alignItems, justifyContent, gap}, "column"),
-    [alignItems, justifyContent, gap],
+    () => propsToDataAttrs({ alignItems, justifyContent, gap, wrapChildren, defaultChildBehavior }, "column"),
+    [alignItems, justifyContent, gap, wrapChildren, defaultChildBehavior]
   );
 
   return (

--- a/registry/nextjs/components/containers/index.tsx
+++ b/registry/nextjs/components/containers/index.tsx
@@ -6,11 +6,9 @@ interface LkContainerProps extends React.HTMLAttributes<HTMLDivElement> {
   maxWidth?: LkContainerWidth;
 }
 
-export default function Container({
-  maxWidth = "md",
-  children,
-  ...restProps
-}: LkContainerProps) {
+export default function Container(props: LkContainerProps) {
+  const { maxWidth = "md", children, ...restProps } = props;
+  
   const dataAttrs = useMemo(
     () => propsToDataAttrs({ maxWidth }, "container"),
     [maxWidth],

--- a/registry/nextjs/components/row/index.tsx
+++ b/registry/nextjs/components/row/index.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/row/row.css";
 
-type LkSizeUnit = "3xs" | "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
+
 
 interface LkRowProps extends React.HTMLAttributes<HTMLDivElement> {
   alignItems?: "start" | "center" | "end" | "stretch";
@@ -13,11 +13,19 @@ interface LkRowProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export default function Row(props: LkRowProps) {
-  const { children, alignItems, justifyContent, gap, wrapChildren, defaultChildBehavior, ...restProps } = props;
+  const {
+    children,
+    alignItems="start",
+    justifyContent="start",
+    gap,
+    wrapChildren,
+    defaultChildBehavior,
+    ...restProps
+  } = props;
 
   console.log("Row props:", restProps);
 
-    const lkRowAttrs = useMemo(
+  const lkRowAttrs = useMemo(
     () =>
       propsToDataAttrs(
         { alignItems, justifyContent, gap, wrapChildren, defaultChildBehavior },

--- a/registry/nextjs/components/section/index.tsx
+++ b/registry/nextjs/components/section/index.tsx
@@ -16,11 +16,11 @@ interface LkSectionProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 export default function Section(props: LkSectionProps) {
-  const { container, children, ...restProps } = props;
+  const { container, children, padding, px, py, pt, pb, pl, pr, ...restProps } = props;
 
   const lkSectionAttrs = useMemo(
-    () => propsToDataAttrs(restProps, "section"),
-    [restProps],
+    () => propsToDataAttrs({ container, children, padding, px, py, pt, pb, pl, pr }, "section"),
+    [container, children, padding, px, py, pt, pb, pl, pr]
   );
 
   return (

--- a/registry/nextjs/components/snackbar/index.tsx
+++ b/registry/nextjs/components/snackbar/index.tsx
@@ -15,17 +15,34 @@ interface LkSnackbarProps extends React.HTMLAttributes<HTMLDivElement> {
   fontClass?: LkFontClass;
 }
 
-export default function Snackbar({
-  badgeColor,
-  primaryButtonColor = "primary",
-  secondaryButtonColor = "secondary",
-  backgroundColor = "surface",
-  globalColor,
-  message = "Notification text goes here.",
-  fontClass = "caption",
-  ...restProps
-}: LkSnackbarProps) {
-  const dataAttrs = useMemo(() => propsToDataAttrs({}, "snackbar"), []);
+export default function Snackbar(props: LkSnackbarProps) {
+  const {
+    badgeColor,
+    primaryButtonColor = "primary",
+    secondaryButtonColor = "secondary",
+    backgroundColor = "surface",
+    globalColor,
+    message = "Notification text goes here.",
+    fontClass = "caption",
+    ...restProps
+  } = props;
+
+  const dataAttrs = useMemo(
+    () =>
+      propsToDataAttrs(
+        {
+          badgeColor,
+          primaryButtonColor,
+          secondaryButtonColor,
+          backgroundColor,
+          globalColor,
+          message,
+          fontClass,
+        },
+        "snackbar"
+      ),
+    [badgeColor, primaryButtonColor, secondaryButtonColor, backgroundColor, globalColor, message, fontClass]
+  );
 
   return (
     <div
@@ -36,19 +53,9 @@ export default function Snackbar({
     >
       <Badge color={globalColor ?? badgeColor} />
       <Text fontClass={fontClass}>{message}</Text>
-      <Button
-        label="Dismiss"
-        size="sm"
-        variant="outline"
-        color={globalColor ?? secondaryButtonColor}
-      />
+      <Button label="Dismiss" size="sm" variant="outline" color={globalColor ?? secondaryButtonColor} />
 
-      <Button
-        label="Undo"
-        size="sm"
-        variant="fill"
-        color={globalColor ?? primaryButtonColor}
-      />
+      <Button label="Undo" size="sm" variant="fill" color={globalColor ?? primaryButtonColor} />
     </div>
   );
 }

--- a/registry/nextjs/components/tab-link/index.tsx
+++ b/registry/nextjs/components/tab-link/index.tsx
@@ -10,20 +10,27 @@ interface LkTabLinkProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactElement<HTMLDivElement>;
 }
 
-export default function TabLink({
-  selected = false,
-  fontClass = "body",
-  indicatorClass = "lk-indicator",
-  children,
-  ...rest
-}: LkTabLinkProps) {
+export default function TabLink(props: LkTabLinkProps) {
+
+
+  const {
+    selected = false,
+    fontClass = "body",
+    indicatorClass = "lk-indicator",
+    children,
+    ...restProps
+  } = props;
+
+
   const dataAttrs = useMemo(
-    () => propsToDataAttrs({ selected }, "tab-link"),
+    () => propsToDataAttrs({ selected, fontClass, indicatorClass }, "tab-link"),
     [selected],
   );
+
+
   console.log("Selected:", selected);
   return (
-    <div lk-component="tab-link" {...dataAttrs} {...rest}>
+    <div lk-component="tab-link" {...dataAttrs} {...restProps}>
       <div lk-slot="child">
         <Text fontClass={fontClass} style={selected ? { fontWeight: 700 } : {}}>
           {children}

--- a/registry/nextjs/components/tab-menu/index.tsx
+++ b/registry/nextjs/components/tab-menu/index.tsx
@@ -7,35 +7,33 @@ import "@/registry/nextjs/components/tab-menu/tab-menu.css";
 interface LkTabMenuProps extends React.HTMLAttributes<HTMLDivElement> {
   tabLinks?: string[];
   alignItems?: "start" | "center" | "end" | "stretch";
-  justifyContent?:
-    | "start"
-    | "center"
-    | "end"
-    | "space-between"
-    | "space-around";
+  justifyContent?: "start" | "center" | "end" | "space-between" | "space-around";
   activeTab: number;
   setActiveTab: (index: number) => void;
 }
 
-export default function TabMenu({
-  tabLinks = ["Tab Link 1", "Tab Link 2", "Tab Link 3"],
-  alignItems,
-  justifyContent,
-  activeTab,
-  setActiveTab,
-  ...rest
-}: LkTabMenuProps) {
-  const dataAttrs = useMemo(() => propsToDataAttrs({}, "tab-menu"), []);
+export default function TabMenu(props: LkTabMenuProps) {
+  const {
+    tabLinks = ["Tab Link 1", "Tab Link 2", "Tab Link 3"],
+    alignItems,
+    justifyContent,
+    activeTab,
+    setActiveTab,
+    ...restProps
+  } = props;
+
+/**Don't include tabLinks or setActiveTab props in the useMemo hook, because they don't affect CSS. */
+
+  const dataAttrs = useMemo(
+    () => propsToDataAttrs({ alignItems, justifyContent, activeTab }, "tab-menu"),
+    [alignItems, justifyContent, activeTab]
+  );
 
   return (
-    <div lk-component="tab-menu" {...dataAttrs} {...rest}>
+    <div lk-component="tab-menu" {...dataAttrs} {...restProps}>
       <Row alignItems={alignItems} justifyContent={justifyContent}>
         {tabLinks.map((label, index) => (
-          <TabLink
-            key={index}
-            selected={index === activeTab}
-            onClick={() => setActiveTab(index)}
-          >
+          <TabLink key={index} selected={index === activeTab} onClick={() => setActiveTab(index)}>
             <div>{label ?? "Tab Link"}</div>
           </TabLink>
         ))}

--- a/registry/nextjs/components/tabs/index.tsx
+++ b/registry/nextjs/components/tabs/index.tsx
@@ -12,19 +12,15 @@ interface LkTabsProps extends React.HTMLAttributes<HTMLDivElement> {
   setActiveTab: (index: number) => void;
 }
 
-export default function Tabs({
-  tabLinks,
-  activeTab,
-  setActiveTab,
-  children,
-  ...rest
-}: LkTabsProps) {
+export default function Tabs(props: LkTabsProps) {
   // const [activeTab] = useState(0);
 
-  const dataAttrs = useMemo(() => propsToDataAttrs({}, "tabs"), []);
+  const { tabLinks, activeTab, setActiveTab, children, ...restProps } = props;
+
+  const dataAttrs = useMemo(() => propsToDataAttrs({activeTab}, "tabs"), [activeTab]);
 
   return (
-    <div lk-component="tabs" {...dataAttrs} {...rest}>
+    <div lk-component="tabs" {...dataAttrs} {...restProps}>
       <TabMenu
         tabLinks={tabLinks}
         justifyContent="start"
@@ -34,10 +30,7 @@ export default function Tabs({
       />
       <div lk-tabs-el="tab-content">
         {children.map((child, index) => (
-          <div
-            key={index}
-            style={{ display: index === activeTab ? "block" : "none" }}
-          >
+          <div key={index} style={{ display: index === activeTab ? "block" : "none" }}>
             {child}
           </div>
         ))}

--- a/registry/nextjs/components/text-input/index.tsx
+++ b/registry/nextjs/components/text-input/index.tsx
@@ -9,14 +9,9 @@ interface LkTextInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export default function TextInput(props: LkTextInputProps) {
-  const { ...restProps } = props;
+  const { labelPosition = "default", helpText, placeholderText, ...restProps } = props;
 
-  const lkTextInputAttrs = useMemo(
-    () => propsToDataAttrs(restProps, "lk-text-input"),
-    [restProps],
-  );
+  const lkTextInputAttrs = useMemo(() => propsToDataAttrs(restProps, "lk-text-input"), [restProps]);
 
-  return (
-    <div {...lkTextInputAttrs}>{/* implementation omitted for brevity */}</div>
-  );
+  return <div {...lkTextInputAttrs}>{/* implementation omitted for brevity */}</div>;
 }

--- a/registry/nextjs/components/text/index.tsx
+++ b/registry/nextjs/components/text/index.tsx
@@ -11,20 +11,15 @@ interface LkTextProps extends React.HTMLAttributes<HTMLElement> {
   tag?: LkSemanticTag;
 }
 
-export default function Text({
-  tag = "div",
-  fontClass = "display2-bold",
-  color,
-  children,
-  style,
-  ...rest
-}: LkTextProps) {
+export default function Text(props: LkTextProps) {
+  const { tag = "div", fontClass = "display2-bold", color, children, style, ...restProps } = props;
   const Tag = tag as ElementType;
 
-  const textAttrs = useMemo(() => propsToDataAttrs(rest, "text"), [rest]);
+  /**Temporarily removing the attr spreader because it's not being used */
+  // const textAttrs = useMemo(() => propsToDataAttrs(restProps, "text"), [restProps]);
 
   return (
-    <Tag className={`${fontClass} color-${color}`} style={style} {...textAttrs}>
+    <Tag className={`${fontClass} color-${color}`} style={style} {...restProps}>
       {children}
     </Tag>
   );

--- a/registry/nextjs/components/theme/index.tsx
+++ b/registry/nextjs/components/theme/index.tsx
@@ -246,6 +246,10 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     updateTheme(palette);
 
+
+    /**TODO: Debundle scroll behavior overrides from the central theme context */
+    /**This is such a confusing place to put it. */
+
     const disableScrollOnNumberInputs = (event: WheelEvent) => {
       const activeElement = document.activeElement as HTMLInputElement;
       if (activeElement?.type === "number") {


### PR DESCRIPTION
- related to #142
- fixes implicit destructuring in column, row, section, snackbar, tab-link, tab-menu, tabs, text, text-input
- removes redundant type definition of LkSizeUnit from Row component