### PR TITLE
Qa/menu item

### DIFF
--- a/registry/nextjs/components/icon/index.tsx
+++ b/registry/nextjs/components/icon/index.tsx
@@ -2,7 +2,7 @@ import { DynamicIcon } from "lucide-react/dynamic";
 import type { IconName } from "lucide-react/dynamic";
 import "@/registry/nextjs/components/icon/icon.css";
 
-interface LkIconProps extends React.HTMLAttributes<HTMLElement> {
+export interface LkIconProps extends React.HTMLAttributes<HTMLElement> {
   name?: IconName;
   fontClass?: Exclude<LkFontClass, `${string}-bold` | `${string}-mono`>;
   color?: LkColor | "currentColor";

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -1,3 +1,20 @@
+/**
+ * A menu item component that displays content with optional start and end icons.
+ * 
+ * @param startIcon - Optional icon to display at the start of the menu item
+ * @param endIcon - Optional icon to display at the end of the menu item
+ * @param children - The content to display in the menu item
+ * @param restProps - Additional HTML div attributes passed through to the component
+ * 
+ * @returns A menu item component with icons, content, and a state layer for interactions
+ * 
+ * @example
+ * ```tsx
+ * <MenuItem startIcon="🏠" endIcon="→">
+ *   Home
+ * </MenuItem>
+ * ```
+ */
 import { useMemo } from "react";
 import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/menu-item/menu-item.css";
@@ -7,6 +24,8 @@ interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
   endIcon?: string;
   children?: React.ReactNode;
 }
+
+
 
 export default function MenuItem({
   startIcon,

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -34,7 +34,7 @@ export default function MenuItem({ startIcon, endIcon, children, ...restProps }:
   return (
     <div lk-component="menu-item" {...dataAttrs}>
       {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
-      <span>{children}</span>
+      <p lk-menu-item-element="content-wrap">{children}</p>
       {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
       <StateLayer ></StateLayer>
     </div>

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -36,7 +36,7 @@ export default function MenuItem({ startIcon, endIcon, children, ...restProps }:
       {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
       <span>{children}</span>
       {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
-      <StateLayer ></StateLayer>
+      <StateLayer></StateLayer>
     </div>
   );
 }

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -1,10 +1,14 @@
 /**
  * A menu item component that displays content with optional start and end icons.
  *
- * @param startIcon - Optional icon to display at the start of the menu item
- * @param endIcon - Optional icon to display at the end of the menu item
- * @param children - The content to display in the menu item in between the icons
- * @param restProps - Additional HTML div attributes passed through to the component
+ * @param props - The menu item component props
+ * @param props.startIcon - Optional icon configuration to display at the start of the menu item
+ * @param props.endIcon - Optional icon configuration to display at the end of the menu item
+ * @param props.children - The content to display in the menu item between the icons
+ * @param props.fontClass - Font class to apply to the menu item, defaults to "body"
+ * @param props.title - Optional title attribute for the menu item element
+ * @param props.className - Additional CSS classes to apply to the menu item
+ * @param props.restProps - Additional HTML div attributes passed through to the component
  *
  * @returns A menu item component with icons, content, and a state layer for interactions
  *

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -3,7 +3,7 @@
  * 
  * @param startIcon - Optional icon to display at the start of the menu item
  * @param endIcon - Optional icon to display at the end of the menu item
- * @param children - The content to display in the menu item
+ * @param children - The content to display in the menu item in between the icons
  * @param restProps - Additional HTML div attributes passed through to the component
  * 
  * @returns A menu item component with icons, content, and a state layer for interactions

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -18,13 +18,13 @@
 import { useMemo } from "react";
 import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/menu-item/menu-item.css";
+import type { IconName } from "lucide-react/dynamic";
 
 interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
-  startIcon?: string;
-  endIcon?: string;
+  startIcon?: IconName;
+  endIcon?: IconName;
   children?: React.ReactNode;
 }
-
 
 
 export default function MenuItem({

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -21,10 +21,11 @@ import "@/registry/nextjs/components/menu-item/menu-item.css";
 import StateLayer from "@/registry/nextjs/components/state-layer";
 import type { IconName } from "lucide-react/dynamic";
 import Icon from "@/registry/nextjs/components/icon";
+import { LkIconProps } from "@/registry/nextjs/components/icon";
 
 interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
-  startIcon?: IconName;
-  endIcon?: IconName;
+  startIcon?: LkIconProps;
+  endIcon?: LkIconProps;
   children?: React.ReactNode;
   title?: string;
 }
@@ -34,9 +35,10 @@ export default function MenuItem({ startIcon, endIcon, children, ...restProps }:
 
   return (
     <div lk-component="menu-item" title={typeof children === "string" ? children : ""} {...dataAttrs}>
-      {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
+      {startIcon && <Icon name={startIcon.name} lk-icon-position="start"></Icon>}
       <p lk-menu-item-element="content-wrap">{children}</p>
-      {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
+      <Icon {...endIcon} lk-icon-position="end"></Icon>
+
       <StateLayer></StateLayer>
     </div>
   );

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -20,6 +20,7 @@ import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/menu-item/menu-item.css";
 import StateLayer from "@/registry/nextjs/components/state-layer";
 import type { IconName } from "lucide-react/dynamic";
+import Icon from "@/registry/nextjs/components/icon";
 
 interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
   startIcon?: IconName;
@@ -32,17 +33,9 @@ export default function MenuItem({ startIcon, endIcon, children, ...restProps }:
 
   return (
     <div lk-component="menu-item" {...dataAttrs}>
-      {startIcon && (
-        <i lk-component="icon" lk-icon-position="start">
-          {startIcon}
-        </i>
-      )}
+      {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
       <span>{children}</span>
-      {endIcon && (
-        <i lk-component="icon" lk-icon-position="end">
-          {endIcon}
-        </i>
-      )}
+      {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
       <StateLayer></StateLayer>
     </div>
   );

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -1,13 +1,13 @@
 /**
  * A menu item component that displays content with optional start and end icons.
- * 
+ *
  * @param startIcon - Optional icon to display at the start of the menu item
  * @param endIcon - Optional icon to display at the end of the menu item
  * @param children - The content to display in the menu item in between the icons
  * @param restProps - Additional HTML div attributes passed through to the component
- * 
+ *
  * @returns A menu item component with icons, content, and a state layer for interactions
- * 
+ *
  * @example
  * ```tsx
  * <MenuItem startIcon="🏠" endIcon="→">
@@ -18,6 +18,7 @@
 import { useMemo } from "react";
 import { propsToDataAttrs } from "@/registry/nextjs/lib/utilities";
 import "@/registry/nextjs/components/menu-item/menu-item.css";
+import StateLayer from "@/registry/nextjs/components/state-layer";
 import type { IconName } from "lucide-react/dynamic";
 
 interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -26,17 +27,8 @@ interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
-
-export default function MenuItem({
-  startIcon,
-  endIcon,
-  children,
-  ...restProps
-}: LkMenuItemProps) {
-  const dataAttrs = useMemo(
-    () => propsToDataAttrs(restProps, "menu-item"),
-    [restProps],
-  );
+export default function MenuItem({ startIcon, endIcon, children, ...restProps }: LkMenuItemProps) {
+  const dataAttrs = useMemo(() => propsToDataAttrs(restProps, "menu-item"), [restProps]);
 
   return (
     <div lk-component="menu-item" {...dataAttrs}>
@@ -51,7 +43,7 @@ export default function MenuItem({
           {endIcon}
         </i>
       )}
-      <div lk-component="state-layer"></div>
+      <StateLayer></StateLayer>
     </div>
   );
 }

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -26,17 +26,18 @@ interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
   startIcon?: IconName;
   endIcon?: IconName;
   children?: React.ReactNode;
+  title?: string;
 }
 
 export default function MenuItem({ startIcon, endIcon, children, ...restProps }: LkMenuItemProps) {
   const dataAttrs = useMemo(() => propsToDataAttrs(restProps, "menu-item"), [restProps]);
 
   return (
-    <div lk-component="menu-item" {...dataAttrs}>
+    <div lk-component="menu-item" title={typeof children === "string" ? children : ""} {...dataAttrs}>
       {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
       <p lk-menu-item-element="content-wrap">{children}</p>
       {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
-      <StateLayer ></StateLayer>
+      <StateLayer></StateLayer>
     </div>
   );
 }

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -36,7 +36,7 @@ export default function MenuItem({ startIcon, endIcon, children, ...restProps }:
       {startIcon && <Icon name={startIcon} lk-icon-position="start"></Icon>}
       <span>{children}</span>
       {endIcon && <Icon name={endIcon} lk-icon-position="end"></Icon>}
-      <StateLayer></StateLayer>
+      <StateLayer ></StateLayer>
     </div>
   );
 }

--- a/registry/nextjs/components/menu-item/index.tsx
+++ b/registry/nextjs/components/menu-item/index.tsx
@@ -27,17 +27,19 @@ interface LkMenuItemProps extends React.HTMLAttributes<HTMLDivElement> {
   startIcon?: LkIconProps;
   endIcon?: LkIconProps;
   children?: React.ReactNode;
+  fontClass?: LkFontClass;
   title?: string;
+  className?: string; //explicitly defining because it's used in internal component logic
 }
 
-export default function MenuItem({ startIcon, endIcon, children, ...restProps }: LkMenuItemProps) {
-  const dataAttrs = useMemo(() => propsToDataAttrs(restProps, "menu-item"), [restProps]);
+export default function MenuItem({ startIcon, endIcon, fontClass="body", children, className, ...restProps }: LkMenuItemProps) {
+  // const dataAttrs = useMemo(() => propsToDataAttrs(restProps, "menu-item"), [restProps]); omitting because it is not used
 
   return (
-    <div lk-component="menu-item" title={typeof children === "string" ? children : ""} {...dataAttrs}>
-      {startIcon && <Icon name={startIcon.name} lk-icon-position="start"></Icon>}
+    <div lk-component="menu-item" title={typeof children === "string" ? children : ""} className={`${fontClass} ${className || ''}`}>
+      {startIcon && <Icon {...startIcon} lk-icon-position="start"></Icon>}
       <p lk-menu-item-element="content-wrap">{children}</p>
-      <Icon {...endIcon} lk-icon-position="end"></Icon>
+      {endIcon && <Icon {...endIcon} lk-icon-position="end"></Icon>}
 
       <StateLayer></StateLayer>
     </div>

--- a/registry/nextjs/components/menu-item/menu-item.css
+++ b/registry/nextjs/components/menu-item/menu-item.css
@@ -1,12 +1,17 @@
 [lk-component="menu-item"] {
+  --py: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
+  --gap: calc(var(--py) / var(--lk-eighthstep));
+
   display: inline-flex;
   align-items: center;
   gap: var(--lk-size-sm);
   border-radius: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
-  padding-top: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
-  padding-bottom: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
+  padding-top: var(--py);
+  padding-bottom: var(--py);
+  gap: var(--gap);
   position: relative;
   overflow: hidden;
+  cursor: pointer;
 }
 
 /* Left padding with start icon */
@@ -28,6 +33,6 @@
   padding-right: var(--body-font-size);
 }
 
-[lk-component="menu-item"]>[lk-component="state-layer"] {
+[lk-component="menu-item"] > [lk-component="state-layer"] {
   border-radius: var(--lk-size-xs);
 }

--- a/registry/nextjs/components/menu-item/menu-item.css
+++ b/registry/nextjs/components/menu-item/menu-item.css
@@ -10,8 +10,17 @@
   padding-bottom: var(--py);
   gap: var(--gap);
   position: relative;
+
+  /* Required for text-overflow ellipsis */
   overflow: hidden;
   cursor: pointer;
+}
+
+[lk-menu-item-element="content-wrap"] {
+  flex: 1 0 0;
+  overflow: hidden;
+  white-space: nowrap; 
+  text-overflow: ellipsis;
 }
 
 /* Left padding with start icon */

--- a/registry/nextjs/components/menu-item/menu-item.css
+++ b/registry/nextjs/components/menu-item/menu-item.css
@@ -6,6 +6,7 @@
   padding-top: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
   padding-bottom: calc(var(--lk-size-lg) * var(--lk-halfstep-dec));
   position: relative;
+  overflow: hidden;
 }
 
 /* Left padding with start icon */

--- a/registry/nextjs/components/state-layer/index.tsx
+++ b/registry/nextjs/components/state-layer/index.tsx
@@ -4,15 +4,12 @@ interface StateLayerProps {
   bgColor?: LkColor;
 }
 
-export default function StateLayer(props: StateLayerProps) {
-  const { bgColor } = props;
-
+export default function StateLayer({ bgColor = "onsurface" }: StateLayerProps) {
   console.log(bgColor);
 
   return (
     <>
       <div lk-component="state-layer" className={`bg-${bgColor}`}></div>
-
     </>
   );
 }

--- a/registry/nextjs/components/state-layer/index.tsx
+++ b/registry/nextjs/components/state-layer/index.tsx
@@ -4,8 +4,8 @@ interface StateLayerProps {
   bgColor?: LkColor | "currentColor";
 }
 
-export default function StateLayer({ bgColor = "onsurface" }: StateLayerProps) {
-  console.log(bgColor);
+export default function StateLayer({ bgColor="currentColor"}: StateLayerProps) {
+  console.log('statelayer bgColor:', bgColor);
 
   return (
     <>

--- a/registry/nextjs/components/state-layer/index.tsx
+++ b/registry/nextjs/components/state-layer/index.tsx
@@ -1,7 +1,7 @@
 import "@/registry/nextjs/components/state-layer/state-layer.css";
 
 interface StateLayerProps {
-  bgColor?: LkColor;
+  bgColor?: LkColor | "currentColor";
 }
 
 export default function StateLayer({ bgColor = "onsurface" }: StateLayerProps) {
@@ -9,7 +9,11 @@ export default function StateLayer({ bgColor = "onsurface" }: StateLayerProps) {
 
   return (
     <>
-      <div lk-component="state-layer" className={`bg-${bgColor}`}></div>
+      <div
+        lk-component="state-layer"
+        className={bgColor !== "currentColor" ? `bg-${bgColor}` : ""}
+        style={bgColor === "currentColor" ? { backgroundColor: "currentColor" } : {}}
+      ></div>
     </>
   );
 }

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -8,6 +8,7 @@ import Container from "@/registry/nextjs/components/containers";
 import Grid from "@/registry/nextjs/components/grid";
 import MenuItem from "@/registry/nextjs/components/menu-item";
 import type { IconName } from "lucide-react/dynamic";
+import { LkIconProps } from "@/registry/nextjs/components/icon";
 
 export default function MenuItemStaging() {
   const fontClasses: LkFontClass[] = [
@@ -92,48 +93,83 @@ export default function MenuItemStaging() {
 
   return (
     <>
-      <Section>
-        <Heading tag="h2">Image Component Tests</Heading>
-        <MenuItemGroup color="primary" />
+      <Section padding="md">
+        <Container>
+          <Heading tag="h2" className="m-bottom-md">
+            Menu Item Component Tests
+          </Heading>
+        </Container>
+
+        {fontClasses.map((fontClass) => (
+          <Container className="m-bottom-xl" key={fontClass}>
+            <h2 className="subheading mono m-bottom-xs">
+              fontClass=<strong className="color-primary">{fontClass}</strong>
+            </h2>
+            <MenuItemGroup color="onsurface" fontClass={fontClass} />
+          </Container>
+        ))}
+        <MenuItemGroup color="warning" />
       </Section>
     </>
   );
 }
 
-function MenuItemGroup({ color = "primary" }: { color?: LkColor | string }) {
+function MenuItemGroup({
+  color = "warning",
+  fontClass = "body",
+}: {
+  color?: LkColor | string;
+  fontClass?: LkFontClass;
+}) {
   return (
     <>
       <div className="bg-surfacecontainerhigh p-xl">
         <Row gap="md">
           <div className={`tempcard color-${color}`}>
-            <MenuItem>Start icon</MenuItem>
-            <MenuItem>Start icon with long text</MenuItem>
-            <MenuItem>boop</MenuItem>
-            <MenuItem>Start icon with extremely long text</MenuItem>
+            <MenuItem fontClass={fontClass}>Start icon</MenuItem>
+            <MenuItem fontClass={fontClass}>Start icon with long text</MenuItem>
+            <MenuItem fontClass={fontClass}>boop</MenuItem>
+            <MenuItem fontClass={fontClass}>Start icon with extremely long text</MenuItem>
           </div>
           <div className={`tempcard color-${color}`}>
-            <MenuItem startIcon="circle">Start icon</MenuItem>
-            <MenuItem startIcon="circle">Start icon with long text</MenuItem>
-            <MenuItem startIcon="circle">boop</MenuItem>
-            <MenuItem startIcon="circle">Start icon with extremely long text</MenuItem>
-          </div>
-          <div className={`tempcard color-${color}`}>
-            <MenuItem endIcon="arrow-right">End icon</MenuItem>
-            <MenuItem endIcon="arrow-right">End icon with long text</MenuItem>
-            <MenuItem endIcon="arrow-right">boop</MenuItem>
-            <MenuItem endIcon="arrow-right">End icon with extremely long text</MenuItem>
-          </div>
-          <div className={`tempcard color-${color}`}>
-            <MenuItem startIcon="circle" endIcon="arrow-right">
-              End icon
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig}>
+              Start icon
             </MenuItem>
-            <MenuItem startIcon="circle" endIcon="arrow-right">
-              End icon with long text
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig}>
+              Start icon with long text
             </MenuItem>
-            <MenuItem startIcon="circle" endIcon="arrow-right">
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig}>
               boop
             </MenuItem>
-            <MenuItem startIcon="circle" endIcon="arrow-right">
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig}>
+              Start icon with extremely long text
+            </MenuItem>
+          </div>
+          <div className={`tempcard color-${color}`}>
+            <MenuItem fontClass={fontClass} endIcon={endIconConfig}>
+              End icon
+            </MenuItem>
+            <MenuItem fontClass={fontClass} endIcon={endIconConfig}>
+              End icon with long text
+            </MenuItem>
+            <MenuItem fontClass={fontClass} endIcon={endIconConfig}>
+              boop
+            </MenuItem>
+            <MenuItem fontClass={fontClass} endIcon={endIconConfig}>
+              End icon with extremely long text
+            </MenuItem>
+          </div>
+          <div className={`tempcard color-${color}`}>
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig} endIcon={endIconConfig}>
+              End icon
+            </MenuItem>
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig} endIcon={endIconConfig}>
+              End icon with long text
+            </MenuItem>
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig} endIcon={endIconConfig}>
+              boop
+            </MenuItem>
+            <MenuItem fontClass={fontClass} startIcon={startIconConfig} endIcon={endIconConfig}>
               End icon with extremely long text
             </MenuItem>
           </div>
@@ -155,3 +191,19 @@ function MenuItemGroup({ color = "primary" }: { color?: LkColor | string }) {
     </>
   );
 }
+
+const startIconConfig: LkIconProps = {
+  name: "circle",
+  fontClass: "body",
+  color: "error",
+  display: "block",
+  strokeWidth: 4,
+};
+
+const endIconConfig: LkIconProps = {
+  name: "arrow-right",
+  fontClass: "body",
+  color: "success",
+  display: "block",
+  strokeWidth: 2,
+};

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -7,8 +7,89 @@ import Image from "@/registry/nextjs/components/image";
 import Container from "@/registry/nextjs/components/containers";
 import Grid from "@/registry/nextjs/components/grid";
 import MenuItem from "@/registry/nextjs/components/menu-item";
+import type { IconName } from "lucide-react/dynamic";
 
 export default function MenuItemStaging() {
+  const fontClasses: LkFontClass[] = [
+    "display1",
+    "display2",
+    "title1",
+    "title2",
+    "title3",
+    "heading",
+    "subheading",
+    "body",
+    "callout",
+    "label",
+    "caption",
+    "capline",
+  ];
+
+  const lkColors: LkColor[] = [
+    "primary",
+    "onprimary",
+    "primarycontainer",
+    "onprimarycontainer",
+    "secondary",
+    "onsecondary",
+    "secondarycontainer",
+    "onsecondarycontainer",
+    "tertiary",
+    "ontertiary",
+    "tertiarycontainer",
+    "ontertiarycontainer",
+    "error",
+    "onerror",
+    "errorcontainer",
+    "onerrorcontainer",
+    "background",
+    "onbackground",
+    "surface",
+    "onsurface",
+    "surfacevariant",
+    "onsurfacevariant",
+    "shadow",
+    "inversesurface",
+    "scrim",
+    "inverseonsurface",
+    "inverseprimary",
+    "success",
+    "onsuccess",
+    "successcontainer",
+    "onsuccesscontainer",
+    "warning",
+    "onwarning",
+    "warningcontainer",
+    "onwarningcontainer",
+    "info",
+    "oninfo",
+    "infocontainer",
+    "oninfocontainer",
+    "primaryfixed",
+    "onprimaryfixed",
+    "primaryfixeddim",
+    "onprimaryfixedvariant",
+    "secondaryfixed",
+    "onsecondaryfixed",
+    "secondaryfixeddim",
+    "onsecondaryfixedvariant",
+    "tertiaryfixed",
+    "ontertiaryfixed",
+    "tertiaryfixeddim",
+    "ontertiaryfixedvariant",
+    "surfacedim",
+    "surfacebright",
+    "surfacecontainerlowest",
+    "surfacecontainerlow",
+    "surfacecontainer",
+    "surfacecontainerhigh",
+    "surfacecontainerhighest",
+    "outline",
+    "outlinevariant",
+  ];
+
+  const testIcons: IconName[] = ["arrow-right", "circle"];
+
   return (
     <>
       <Section>

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -103,12 +103,14 @@ export default function MenuItemStaging() {
 function MenuItemGroup() {
   return (
     <>
-      <MenuItem>No icon</MenuItem>
-      <MenuItem startIcon="circle">Start icon</MenuItem>
-      <MenuItem endIcon="arrow-right">End icon</MenuItem>
-      <MenuItem startIcon="circle" endIcon="arrow-right">
-        Both icons
-      </MenuItem>
+      <Row gap="md">
+        <MenuItem>No icon</MenuItem>
+        <MenuItem startIcon="circle">Start icon</MenuItem>
+        <MenuItem endIcon="arrow-right">End icon</MenuItem>
+        <MenuItem startIcon="circle" endIcon="arrow-right">
+          Both icons
+        </MenuItem>
+      </Row>
     </>
   );
 }

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -94,8 +94,21 @@ export default function MenuItemStaging() {
     <>
       <Section>
         <Heading tag="h2">Image Component Tests</Heading>
-        <MenuItem></MenuItem>
+        <MenuItemGroup />
       </Section>
+    </>
+  );
+}
+
+function MenuItemGroup() {
+  return (
+    <>
+      <MenuItem>No icon</MenuItem>
+      <MenuItem startIcon="circle">Start icon</MenuItem>
+      <MenuItem endIcon="arrow-right">End icon</MenuItem>
+      <MenuItem startIcon="circle" endIcon="arrow-right">
+        Both icons
+      </MenuItem>
     </>
   );
 }

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+import Column from "@/registry/nextjs/components/column";
+import Heading from "@/registry/nextjs/components/heading";
+import Row from "@/registry/nextjs/components/row";
+import Section from "@/registry/nextjs/components/section";
+import Image from "@/registry/nextjs/components/image";
+import Container from "@/registry/nextjs/components/containers";
+import Grid from "@/registry/nextjs/components/grid";
+import MenuItem from "@/registry/nextjs/components/menu-item";
+
+export default function MenuItemStaging() {
+  return (
+    <>
+      <Section>
+        <Heading tag="h2">Image Component Tests</Heading>
+        <MenuItem></MenuItem>
+      </Section>
+    </>
+  );
+}

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -103,14 +103,28 @@ export default function MenuItemStaging() {
 function MenuItemGroup() {
   return (
     <>
-      <Row gap="md">
-        <MenuItem>No icon</MenuItem>
-        <MenuItem startIcon="circle">Start icon</MenuItem>
-        <MenuItem endIcon="arrow-right">End icon</MenuItem>
-        <MenuItem startIcon="circle" endIcon="arrow-right">
-          Both icons
-        </MenuItem>
-      </Row>
+      <body className="bg-surfacecontainerhigh">
+        <Row gap="md">
+          <div className="tempcard">
+            <MenuItem>No icon</MenuItem>
+            <MenuItem startIcon="circle">Start icon</MenuItem>
+            <MenuItem endIcon="arrow-right">End icon</MenuItem>
+            <MenuItem startIcon="circle" endIcon="arrow-right">
+              Both icons
+            </MenuItem>
+          </div>
+        </Row>
+      </body>
+
+      <style jsx>{`
+        .tempcard {
+          padding: 1em;
+          background-color: var(--lk-surfacecontainerlowest);
+          border-radius: 0.5em;
+          display: flex;
+          flex-flow: column nowrap;
+        }
+      `}</style>
     </>
   );
 }

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -94,36 +94,36 @@ export default function MenuItemStaging() {
     <>
       <Section>
         <Heading tag="h2">Image Component Tests</Heading>
-        <MenuItemGroup />
+        <MenuItemGroup color="primary" />
       </Section>
     </>
   );
 }
 
-function MenuItemGroup() {
+function MenuItemGroup({ color = "primary" }: { color?: LkColor | string }) {
   return (
     <>
       <div className="bg-surfacecontainerhigh p-xl">
         <Row gap="md">
-          <div className="tempcard">
+          <div className={`tempcard color-${color}`}>
             <MenuItem>Start icon</MenuItem>
             <MenuItem>Start icon with long text</MenuItem>
             <MenuItem>boop</MenuItem>
             <MenuItem>Start icon with extremely long text</MenuItem>
           </div>
-          <div className="tempcard">
+          <div className={`tempcard color-${color}`}>
             <MenuItem startIcon="circle">Start icon</MenuItem>
             <MenuItem startIcon="circle">Start icon with long text</MenuItem>
             <MenuItem startIcon="circle">boop</MenuItem>
             <MenuItem startIcon="circle">Start icon with extremely long text</MenuItem>
           </div>
-          <div className="tempcard">
+          <div className={`tempcard color-${color}`}>
             <MenuItem endIcon="arrow-right">End icon</MenuItem>
             <MenuItem endIcon="arrow-right">End icon with long text</MenuItem>
             <MenuItem endIcon="arrow-right">boop</MenuItem>
             <MenuItem endIcon="arrow-right">End icon with extremely long text</MenuItem>
           </div>
-          <div className="tempcard">
+          <div className={`tempcard color-${color}`}>
             <MenuItem startIcon="circle" endIcon="arrow-right">
               End icon
             </MenuItem>

--- a/src/app/staging/menu-item/page.tsx
+++ b/src/app/staging/menu-item/page.tsx
@@ -103,18 +103,42 @@ export default function MenuItemStaging() {
 function MenuItemGroup() {
   return (
     <>
-      <body className="bg-surfacecontainerhigh">
+      <div className="bg-surfacecontainerhigh p-xl">
         <Row gap="md">
           <div className="tempcard">
-            <MenuItem>No icon</MenuItem>
+            <MenuItem>Start icon</MenuItem>
+            <MenuItem>Start icon with long text</MenuItem>
+            <MenuItem>boop</MenuItem>
+            <MenuItem>Start icon with extremely long text</MenuItem>
+          </div>
+          <div className="tempcard">
             <MenuItem startIcon="circle">Start icon</MenuItem>
+            <MenuItem startIcon="circle">Start icon with long text</MenuItem>
+            <MenuItem startIcon="circle">boop</MenuItem>
+            <MenuItem startIcon="circle">Start icon with extremely long text</MenuItem>
+          </div>
+          <div className="tempcard">
             <MenuItem endIcon="arrow-right">End icon</MenuItem>
+            <MenuItem endIcon="arrow-right">End icon with long text</MenuItem>
+            <MenuItem endIcon="arrow-right">boop</MenuItem>
+            <MenuItem endIcon="arrow-right">End icon with extremely long text</MenuItem>
+          </div>
+          <div className="tempcard">
             <MenuItem startIcon="circle" endIcon="arrow-right">
-              Both icons
+              End icon
+            </MenuItem>
+            <MenuItem startIcon="circle" endIcon="arrow-right">
+              End icon with long text
+            </MenuItem>
+            <MenuItem startIcon="circle" endIcon="arrow-right">
+              boop
+            </MenuItem>
+            <MenuItem startIcon="circle" endIcon="arrow-right">
+              End icon with extremely long text
             </MenuItem>
           </div>
         </Row>
-      </body>
+      </div>
 
       <style jsx>{`
         .tempcard {
@@ -123,6 +147,9 @@ function MenuItemGroup() {
           border-radius: 0.5em;
           display: flex;
           flex-flow: column nowrap;
+          flex: 1 0 0;
+          flex-basis: 0;
+          overflow: hidden;
         }
       `}</style>
     </>


### PR DESCRIPTION
Related to #155. See commits for detailed summary.

Overview of changes:
- Create staging area
- Documents params
- Adds `text-overflow: ellipsis` to menu item label
- Applies menu item flex behavior
- Updates startIcon and endIcon props to interface LkIconProps instead of only accepting a "name", so you can control the color strokewidth and other iconProps directly via the component instance
- Add new props: fontClass and title
  - fontClass controls all content sizing and padding **in future, should inherit from an enclosing container.**
  - title makes overflowing text appear in full on hover
- Replaces deprecated state layer method with new state layer component
- Replaces deprecated material-symbols icons with actual Lucide React icons
 